### PR TITLE
Add UI for managing Debezium connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Overview
+
+This UI allows you to monitor and control Debezium connectors via the REST API
+exposed by a running Debezium Connect instance. Configure the host of your
+Debezium service (e.g. `http://localhost:8083`) and you'll be able to view,
+create, pause, resume and delete connectors directly from the browser.
+
 ## Available Scripts
 
 In the project directory, you can run:
@@ -10,6 +17,11 @@ In the project directory, you can run:
 
 Runs the app in the development mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+
+When the UI loads, navigate to **Change Host** in the top bar and enter the URL
+of your Debezium Connect instance (e.g. `http://localhost:8083`). Once
+connected, the dashboard will list all available connectors and allow you to
+control them.
 
 The page will reload if you make edits.\
 You will also see any lint errors in the console.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@
 import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import ConnectorListPage from './pages/ConnectorListPage';
+import HostPage from './pages/HostPage';
+import CreateWizard from './components/CreateWizard';
 import TopBar from './components/TopBar';
 import Container from '@mui/material/Container';
 
@@ -11,6 +13,8 @@ const App: React.FC = () => (
     <Container sx={{ marginTop: 4 }}>
       <Routes>
         <Route path="/" element={<ConnectorListPage />} />
+        <Route path="/host" element={<HostPage />} />
+        <Route path="/create" element={<CreateWizard />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </Container>

--- a/src/components/ConnectorTable.tsx
+++ b/src/components/ConnectorTable.tsx
@@ -21,9 +21,10 @@ type ConnectorInfo = {
 
 interface Props {
   connectors: ConnectorInfo[];
+  onActionComplete?: () => void;
 }
 
-const ConnectorTable: React.FC<Props> = ({ connectors }) => {
+const ConnectorTable: React.FC<Props> = ({ connectors, onActionComplete }) => {
   const { state } = useHost();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [selectedConnector, setSelectedConnector] = useState<ConnectorInfo | null>(null);
@@ -60,6 +61,7 @@ const ConnectorTable: React.FC<Props> = ({ connectors }) => {
       const res = await fetchWithTimeout(url, { method }, 5000);
       if (!res.ok) throw new Error(`${action} failed`);
       setSnackbarMsg(`${action.charAt(0).toUpperCase() + action.slice(1)} succeeded`);
+      onActionComplete && onActionComplete();
     } catch (e: any) {
       setSnackbarMsg(`Error: ${e.message}`);
     }

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -5,8 +5,10 @@ import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import { useHost } from '../context/HostContext';
-import HealthPoller from './HealthPoller'; // <-- Fix here
+import { Link as RouterLink } from 'react-router-dom';
+import HealthPoller from './HealthPoller';
 
 const TopBar: React.FC = () => {
   const { state } = useHost();
@@ -22,6 +24,12 @@ const TopBar: React.FC = () => {
             color={state.healthy ? 'success' : 'error'}
             size="small"
           />
+          <Button color="inherit" component={RouterLink} to="/host">
+            Change Host
+          </Button>
+          <Button color="inherit" component={RouterLink} to="/create">
+            New Connector
+          </Button>
           <HealthPoller />
         </Box>
       </Toolbar>

--- a/src/context/HostContext.tsx
+++ b/src/context/HostContext.tsx
@@ -11,9 +11,13 @@ const initialState: HostState = {
   healthy: false,
 };
 
+type HostAction =
+  | { type: 'SET_HOST'; payload: string }
+  | { type: 'SET_HEALTH'; payload: boolean };
+
 type HostContextType = {
   state: HostState;
-  dispatch: React.Dispatch<any>;
+  dispatch: React.Dispatch<HostAction>;
 };
 
 const HostContext = createContext<HostContextType | undefined>(undefined);
@@ -22,12 +26,19 @@ type HostProviderProps = {
   children: ReactNode;
 };
 
+function reducer(state: HostState, action: HostAction): HostState {
+  switch (action.type) {
+    case 'SET_HOST':
+      return { ...state, host: action.payload };
+    case 'SET_HEALTH':
+      return { ...state, healthy: action.payload };
+    default:
+      return state;
+  }
+}
+
 export const HostProvider: React.FC<HostProviderProps> = ({ children }) => {
-  // Dummy reducer; replace with your actual logic
-  const [state, dispatch] = useReducer(
-    (state: HostState, action: any) => ({ ...state, ...action }),
-    initialState
-  );
+  const [state, dispatch] = useReducer(reducer, initialState);
 
   return (
     <HostContext.Provider value={{ state, dispatch }}>

--- a/src/pages/HostPage.tsx
+++ b/src/pages/HostPage.tsx
@@ -1,8 +1,34 @@
 // src/pages/HostPage.tsx
-import React from 'react';
+import React, { useState } from 'react';
+import { Box, Button, TextField, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { useHost } from '../context/HostContext';
 
 const HostPage: React.FC = () => {
-  return <div>Host selection coming soon.</div>;
+  const { state, dispatch } = useHost();
+  const [host, setHost] = useState(state.host || 'http://localhost:8083');
+  const navigate = useNavigate();
+
+  const saveHost = () => {
+    dispatch({ type: 'SET_HOST', payload: host });
+    navigate('/');
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Typography variant="h6">Configure Debezium Host</Typography>
+      <TextField
+        label="Debezium Connect URL"
+        value={host}
+        onChange={(e) => setHost(e.target.value)}
+      />
+      <Box>
+        <Button variant="contained" onClick={saveHost}>
+          Save
+        </Button>
+      </Box>
+    </Box>
+  );
 };
 
 export default HostPage;


### PR DESCRIPTION
## Summary
- enable host selection and connector health handling
- list connectors from Debezium REST API
- allow actions on connectors and creation of new ones
- update top bar with navigation links
- document host configuration steps in README

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885f82ff8d483228415daac86e055c6