### PR TITLE
Add persistent host and refresh home button

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ Runs the app in the development mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
 When the UI loads, navigate to **Change Host** in the top bar and enter the URL
-of your Debezium Connect instance (e.g. `http://localhost:8083`). Once
+of your Debezium Connect instance (e.g. `http://localhost:8083`). The host
+setting is persisted in your browser so it is remembered on refresh. Once
 connected, the dashboard will list all available connectors and allow you to
-control them.
+control them. Use the **Home** button in the top bar to quickly return to the
+dashboard and refresh the connector list.
 
 The page will reload if you make edits.\
 You will also see any lint errors in the console.

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -7,11 +7,17 @@ import Chip from '@mui/material/Chip';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import { useHost } from '../context/HostContext';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import HealthPoller from './HealthPoller';
 
 const TopBar: React.FC = () => {
   const { state } = useHost();
+  const navigate = useNavigate();
+
+  const goHome = () => {
+    navigate('/');
+    window.dispatchEvent(new Event('refresh-connectors'));
+  };
   return (
     <AppBar position="static">
       <Toolbar>
@@ -26,6 +32,9 @@ const TopBar: React.FC = () => {
           />
           <Button color="inherit" component={RouterLink} to="/host">
             Change Host
+          </Button>
+          <Button color="inherit" onClick={goHome}>
+            Home
           </Button>
           <Button color="inherit" component={RouterLink} to="/create">
             New Connector

--- a/src/context/HostContext.tsx
+++ b/src/context/HostContext.tsx
@@ -6,8 +6,11 @@ type HostState = {
   healthy: boolean;
   // ... add other fields as needed
 };
+const storedHost =
+  typeof window !== 'undefined' ? localStorage.getItem('debezium-host') || '' : '';
+
 const initialState: HostState = {
-  host: '',
+  host: storedHost,
   healthy: false,
 };
 
@@ -39,6 +42,14 @@ function reducer(state: HostState, action: HostAction): HostState {
 
 export const HostProvider: React.FC<HostProviderProps> = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
+
+  React.useEffect(() => {
+    if (state.host) {
+      localStorage.setItem('debezium-host', state.host);
+    } else {
+      localStorage.removeItem('debezium-host');
+    }
+  }, [state.host]);
 
   return (
     <HostContext.Provider value={{ state, dispatch }}>

--- a/src/pages/ConnectorListPage.tsx
+++ b/src/pages/ConnectorListPage.tsx
@@ -1,5 +1,5 @@
 // src/pages/ConnectorListPage.tsx
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useHost } from '../context/HostContext';
 import {
   Card,
@@ -33,7 +33,7 @@ const ConnectorListPage: React.FC = () => {
 
   const isConnected = state.healthy && !!state.host;
 
-  const loadConnectors = async () => {
+  const loadConnectors = useCallback(async () => {
     if (!isConnected) {
       setConnectors([]);
       return;
@@ -62,12 +62,18 @@ const ConnectorListPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [isConnected, state.host]);
 
   useEffect(() => {
     loadConnectors();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.host, state.healthy]);
+
+  useEffect(() => {
+    const handler = () => loadConnectors();
+    window.addEventListener('refresh-connectors', handler);
+    return () => window.removeEventListener('refresh-connectors', handler);
+  }, [loadConnectors]);
 
   return (
     <Box>

--- a/src/pages/HostPage.tsx
+++ b/src/pages/HostPage.tsx
@@ -11,6 +11,7 @@ const HostPage: React.FC = () => {
 
   const saveHost = () => {
     dispatch({ type: 'SET_HOST', payload: host });
+    window.dispatchEvent(new Event('refresh-connectors'));
     navigate('/');
   };
 


### PR DESCRIPTION
## Summary
- persist Debezium host in localStorage
- refresh connectors whenever the host is saved
- document the new Home button and host persistence

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68860c54ec2083229119d0e5a09f141e