### PR TITLE
Fix schema history topic for new MySQL connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ dashboard and refresh the connector list.
 
 The creation wizard automatically adds the required `topic.prefix` property to
 new connectors. It also sets
-`schema.history.internal.kafka.bootstrap.servers` to `kafka:9092` by default so
-that MySQL connectors start without additional manual configuration.
+`schema.history.internal.kafka.bootstrap.servers` to `kafka:9092` by default and
+initializes `schema.history.internal.kafka.topic` to `schema-changes.<connector
+name>` so that MySQL connectors start without additional manual configuration.
 
 The page will reload if you make edits.\
 You will also see any lint errors in the console.

--- a/src/components/CreateWizard.tsx
+++ b/src/components/CreateWizard.tsx
@@ -85,6 +85,8 @@ const CreateWizard: React.FC = () => {
       'schema.history.internal.kafka.bootstrap.servers':
         configTemplate['schema.history.internal.kafka.bootstrap.servers'] ||
         'kafka:9092',
+      'schema.history.internal.kafka.topic':
+        `schema-changes.${data.name}`,
       // (add or override more fields if necessary)
     };
   };

--- a/src/templates/mysql.json
+++ b/src/templates/mysql.json
@@ -6,6 +6,7 @@
   "database.password": "pass",
   "database.server.id": "184054",
   "topic.prefix": "fulfillment",
+  "schema.history.internal.kafka.topic": "schema-changes.fulfillment",
   "schema.history.internal.kafka.bootstrap.servers": "kafka:9092",
   "database.include.list": "inventory",
   "plugin.name": "mysql_native_password"


### PR DESCRIPTION
## Summary
- configure a default schema history topic when creating connectors
- update MySQL template with the same topic
- document the defaults in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68861c8702b88322894f0d6ab60cc592