### PR TITLE
Fix connector restart

### DIFF
--- a/src/components/ConnectorTable.tsx
+++ b/src/components/ConnectorTable.tsx
@@ -57,11 +57,14 @@ const ConnectorTable: React.FC<Props> = ({ connectors, onActionComplete }) => {
       let url = `${state.host}/connectors/${name}`;
       if (action === 'pause') url += '/pause';
       if (action === 'resume') url += '/resume';
-      if (action === 'restart') url += '/restart';
+      if (action === 'restart')
+        url += '/restart?includeTasks=true&onlyFailed=true';
       if (action === 'delete') {
         url += ''; // DELETE at connector endpoint
       }
-      const method = (action === 'delete' ? 'DELETE' : 'PUT');
+      let method = 'PUT';
+      if (action === 'delete') method = 'DELETE';
+      if (action === 'restart') method = 'POST';
       const res = await fetchWithTimeout(url, { method }, 5000);
       if (!res.ok) throw new Error(`${action} failed`);
       setSnackbarMsg(`${action.charAt(0).toUpperCase() + action.slice(1)} succeeded`);


### PR DESCRIPTION
## Summary
- fix restart method for Kafka Connect API
- restart failed tasks

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688714cbe898832291052d86ad8138d3