### PR TITLE
Add connector update option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 This UI allows you to monitor and control Debezium connectors via the REST API
 exposed by a running Debezium Connect instance. Configure the host of your
 Debezium service (e.g. `http://localhost:8083`) and you'll be able to view,
-create, pause, resume and delete connectors directly from the browser.
+create, **update**, pause, resume and delete connectors directly from the browser.
 
 ## Available Scripts
 

--- a/src/components/ConnectorFormFields.tsx
+++ b/src/components/ConnectorFormFields.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { TextField } from '@mui/material';
+import { Controller, Control } from 'react-hook-form';
+
+export interface ConnectorFieldValues {
+  name: string;
+  host: string;
+  port: string;
+  username: string;
+  password: string;
+  database: string;
+}
+
+interface Props {
+  control: Control<ConnectorFieldValues>;
+  disableName?: boolean;
+}
+
+const ConnectorFormFields: React.FC<Props> = ({ control, disableName }) => (
+  <>
+    <Controller
+      name="name"
+      control={control}
+      render={({ field, fieldState }) => (
+        <TextField
+          label="Connector Name"
+          {...field}
+          disabled={disableName}
+          error={!!fieldState.error}
+          helperText={fieldState.error?.message}
+          required
+        />
+      )}
+    />
+    <Controller
+      name="host"
+      control={control}
+      render={({ field, fieldState }) => (
+        <TextField
+          label="Host"
+          {...field}
+          error={!!fieldState.error}
+          helperText={fieldState.error?.message}
+          required
+        />
+      )}
+    />
+    <Controller
+      name="port"
+      control={control}
+      render={({ field, fieldState }) => (
+        <TextField
+          label="Port"
+          type="number"
+          {...field}
+          error={!!fieldState.error}
+          helperText={fieldState.error?.message}
+          required
+        />
+      )}
+    />
+    <Controller
+      name="username"
+      control={control}
+      render={({ field, fieldState }) => (
+        <TextField
+          label="User"
+          {...field}
+          error={!!fieldState.error}
+          helperText={fieldState.error?.message}
+          required
+        />
+      )}
+    />
+    <Controller
+      name="password"
+      control={control}
+      render={({ field, fieldState }) => (
+        <TextField
+          label="Password"
+          type="password"
+          {...field}
+          error={!!fieldState.error}
+          helperText={fieldState.error?.message}
+          required
+        />
+      )}
+    />
+    <Controller
+      name="database"
+      control={control}
+      render={({ field, fieldState }) => (
+        <TextField
+          label="Database Name"
+          {...field}
+          error={!!fieldState.error}
+          helperText={fieldState.error?.message}
+          required
+        />
+      )}
+    />
+  </>
+);
+
+export default ConnectorFormFields;

--- a/src/components/ConnectorTable.tsx
+++ b/src/components/ConnectorTable.tsx
@@ -10,6 +10,7 @@ import {
 import { useHost } from '../context/HostContext';
 import ConfirmDialog from './ConfirmDialog';
 import AlertSnackbar from './AlertSnackbar';
+import UpdateDialog from './UpdateDialog';
 import { fetchWithTimeout } from '../utils/api';
 
 type ConnectorInfo = {
@@ -29,6 +30,7 @@ const ConnectorTable: React.FC<Props> = ({ connectors, onActionComplete }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [selectedConnector, setSelectedConnector] = useState<ConnectorInfo | null>(null);
   const [openDialog, setOpenDialog] = useState(false);
+  const [openUpdate, setOpenUpdate] = useState(false);
   const [actionType, setActionType] = useState<string>('');
   const [snackbarMsg, setSnackbarMsg] = useState<string | null>(null);
   const [openRows, setOpenRows] = useState<Record<string, boolean>>({});
@@ -46,6 +48,11 @@ const ConnectorTable: React.FC<Props> = ({ connectors, onActionComplete }) => {
   const confirmDelete = () => {
     setActionType('delete');
     setOpenDialog(true);
+    handleMenuClose();
+  };
+
+  const openUpdateDialog = () => {
+    setOpenUpdate(true);
     handleMenuClose();
   };
 
@@ -170,6 +177,7 @@ const ConnectorTable: React.FC<Props> = ({ connectors, onActionComplete }) => {
         {selectedConnector?.status === 'PAUSED' && (
           <MenuItem onClick={() => { handleAction('resume'); handleMenuClose(); }}>Resume</MenuItem>
         )}
+        <MenuItem onClick={openUpdateDialog}>Update</MenuItem>
         <MenuItem onClick={() => { handleAction('restart'); handleMenuClose(); }}>Restart</MenuItem>
         <MenuItem onClick={confirmDelete} color="error">Delete</MenuItem>
       </Menu>
@@ -180,6 +188,12 @@ const ConnectorTable: React.FC<Props> = ({ connectors, onActionComplete }) => {
         content={`Are you sure you want to delete connector "${selectedConnector?.name}"?`}
         onClose={() => setOpenDialog(false)}
         onConfirm={() => handleAction('delete')}
+      />
+      <UpdateDialog
+        open={openUpdate}
+        connector={selectedConnector?.name || null}
+        onClose={() => setOpenUpdate(false)}
+        onUpdated={() => onActionComplete && onActionComplete()}
       />
       {/* Snackbar for notifications */}
       {snackbarMsg && (

--- a/src/components/CreateWizard.tsx
+++ b/src/components/CreateWizard.tsx
@@ -1,25 +1,28 @@
 // src/components/CreateWizard.tsx
 import React, { useState } from 'react';
 import {
-  Stepper, Step, StepLabel, Button, Box, Typography, TextField, FormControl, MenuItem
+  Stepper,
+  Step,
+  StepLabel,
+  Button,
+  Box,
+  Typography,
+  TextField,
+  FormControl,
+  MenuItem,
 } from '@mui/material';
-import { useForm, Controller, FormProvider } from 'react-hook-form';
+import { useForm, FormProvider, Control } from 'react-hook-form';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useNavigate } from 'react-router-dom';
 import { useHost } from '../context/HostContext';
 import AlertSnackbar from './AlertSnackbar';
 import ConfigEditor from './ConfigEditor';
+import ConnectorFormFields, { ConnectorFieldValues } from './ConnectorFormFields';
 import connectorTemplates from '../templates';
 
-type ConnectorForm = {
+type ConnectorForm = ConnectorFieldValues & {
   type: string;
-  name: string;
-  host: string;
-  port: string;
-  username: string;
-  password: string;
-  database: string;
 };
 
 const connectorTypes = [
@@ -155,48 +158,7 @@ const CreateWizard: React.FC = () => {
         {/* Step 2: Properties */}
         {activeStep === 1 && (
           <Box component="form" noValidate onSubmit={handleSubmit(onNext)} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <Controller
-              name="name"
-              control={control}
-              render={({ field, fieldState }) => (
-                <TextField label="Connector Name" {...field} error={!!fieldState.error} helperText={fieldState.error?.message} required />
-              )}
-            />
-            <Controller
-              name="host"
-              control={control}
-              render={({ field, fieldState }) => (
-                <TextField label="Host" {...field} error={!!fieldState.error} helperText={fieldState.error?.message} required />
-              )}
-            />
-            <Controller
-              name="port"
-              control={control}
-              render={({ field, fieldState }) => (
-                <TextField label="Port" type="number" {...field} error={!!fieldState.error} helperText={fieldState.error?.message} required />
-              )}
-            />
-            <Controller
-              name="username"
-              control={control}
-              render={({ field, fieldState }) => (
-                <TextField label="User" {...field} error={!!fieldState.error} helperText={fieldState.error?.message} required />
-              )}
-            />
-            <Controller
-              name="password"
-              control={control}
-              render={({ field, fieldState }) => (
-                <TextField label="Password" type="password" {...field} error={!!fieldState.error} helperText={fieldState.error?.message} required />
-              )}
-            />
-            <Controller
-              name="database"
-              control={control}
-              render={({ field, fieldState }) => (
-                <TextField label="Database Name" {...field} error={!!fieldState.error} helperText={fieldState.error?.message} required />
-              )}
-            />
+            <ConnectorFormFields control={control as unknown as Control<ConnectorFieldValues>} />
             <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
               <Button variant="outlined" onClick={onBack}>Back</Button>
               <Button type="submit" variant="contained" disabled={!formState.isValid}>Next</Button>

--- a/src/components/UpdateDialog.tsx
+++ b/src/components/UpdateDialog.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box
+} from '@mui/material';
+import { useForm, FormProvider, Control } from 'react-hook-form';
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useHost } from '../context/HostContext';
+import { fetchWithTimeout } from '../utils/api';
+import AlertSnackbar from './AlertSnackbar';
+import ConnectorFormFields, { ConnectorFieldValues } from './ConnectorFormFields';
+
+interface UpdateDialogProps {
+  open: boolean;
+  connector: string | null;
+  onClose: () => void;
+  onUpdated: () => void;
+}
+
+const schema = yup.object({
+  name: yup.string(),
+  host: yup.string().required('Host is required'),
+  port: yup.string().required('Port is required').matches(/^\d+$/, 'Port must be a number'),
+  username: yup.string().required('User is required'),
+  password: yup.string().required('Password is required'),
+  database: yup.string().required('Database name is required'),
+});
+
+const UpdateDialog: React.FC<UpdateDialogProps> = ({ open, connector, onClose, onUpdated }) => {
+  const { state } = useHost();
+  const methods = useForm<ConnectorFieldValues>({ resolver: yupResolver(schema) });
+  const { control, reset, handleSubmit, formState } = methods;
+  const [baseConfig, setBaseConfig] = useState<any | null>(null);
+  const [snackbarMsg, setSnackbarMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !connector) return;
+    const load = async () => {
+      try {
+        const res = await fetchWithTimeout(
+          `${state.host}/connectors/${connector}/config`,
+          {},
+          5000
+        );
+        if (!res.ok) throw new Error('Failed to fetch config');
+        const cfg = await res.json();
+        setBaseConfig(cfg);
+        reset({
+          name: connector,
+          host: cfg['database.hostname'] || '',
+          port: String(cfg['database.port'] || ''),
+          username: cfg['database.user'] || '',
+          password: cfg['database.password'] || '',
+          database: cfg['database.dbname'] || '',
+        });
+      } catch (e: any) {
+        setSnackbarMsg('Error: ' + e.message);
+      }
+    };
+    load();
+  }, [open, connector, state.host, reset]);
+
+  const handleUpdate = async (data: ConnectorFieldValues) => {
+    if (!connector || !baseConfig) return;
+    try {
+      const newConfig = {
+        ...baseConfig,
+        'database.hostname': data.host,
+        'database.port': Number(data.port),
+        'database.user': data.username,
+        'database.password': data.password,
+        'database.dbname': data.database,
+      };
+      const res = await fetchWithTimeout(
+        `${state.host}/connectors/${connector}/config`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(newConfig),
+        },
+        5000
+      );
+      if (!res.ok) throw new Error('Update failed');
+      setSnackbarMsg('Update succeeded');
+      onUpdated();
+      onClose();
+    } catch (e: any) {
+      setSnackbarMsg('Error: ' + e.message);
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+        <DialogTitle>Update {connector}</DialogTitle>
+        <FormProvider {...methods}>
+          <Box component="form" onSubmit={handleSubmit(handleUpdate)}>
+            <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <ConnectorFormFields control={control as unknown as Control<ConnectorFieldValues>} disableName />
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={onClose}>Cancel</Button>
+              <Button variant="contained" type="submit" disabled={!formState.isValid}>Update</Button>
+            </DialogActions>
+          </Box>
+        </FormProvider>
+      </Dialog>
+      {snackbarMsg && (
+        <AlertSnackbar message={snackbarMsg} onClose={() => setSnackbarMsg(null)} />
+      )}
+    </>
+  );
+};
+
+export default UpdateDialog;


### PR DESCRIPTION
## Summary
- add UpdateDialog component for editing connector configuration
- expose update action from ConnectorTable dropdown
- mention update capability in README
- reuse connector form fields for update dialog

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68879180cdc083229c00323cf03012fb