### PR TITLE
Fix CreateWizard and UpdateDialog typing

### DIFF
--- a/src/components/CreateWizard.tsx
+++ b/src/components/CreateWizard.tsx
@@ -11,7 +11,7 @@ import {
   FormControl,
   MenuItem,
 } from '@mui/material';
-import { useForm, FormProvider, Control } from 'react-hook-form';
+import { useForm, FormProvider, Control, Controller } from 'react-hook-form';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useNavigate } from 'react-router-dom';

--- a/src/components/UpdateDialog.tsx
+++ b/src/components/UpdateDialog.tsx
@@ -33,7 +33,7 @@ const schema = yup.object({
 
 const UpdateDialog: React.FC<UpdateDialogProps> = ({ open, connector, onClose, onUpdated }) => {
   const { state } = useHost();
-  const methods = useForm<ConnectorFieldValues>({ resolver: yupResolver(schema) });
+  const methods = useForm<ConnectorFieldValues>({ resolver: yupResolver<ConnectorFieldValues>(schema) });
   const { control, reset, handleSubmit, formState } = methods;
   const [baseConfig, setBaseConfig] = useState<any | null>(null);
   const [snackbarMsg, setSnackbarMsg] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- add missing Controller import in CreateWizard
- type yupResolver in UpdateDialog

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688798d2768c8322ab84305ddb0eb71c