### PR TITLE
Add expert connector creation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ new connectors. It also sets
 initializes `schema.history.internal.kafka.topic` to `schema-changes.<connector
 name>` so that MySQL connectors start without additional manual configuration.
 
+For advanced tuning you can enable the expert mode by appending `?beta=true` to
+the URL and using the "Switch to expert mode" link on the first step of the
+wizard. This opens a JSON editor for pasting a full Debezium configuration.
+
 The page will reload if you make edits.\
 You will also see any lint errors in the console.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import ConnectorListPage from './pages/ConnectorListPage';
 import HostPage from './pages/HostPage';
 import CreateWizard from './components/CreateWizard';
+import ExpertCreate from './components/ExpertCreate';
 import TopBar from './components/TopBar';
 import Container from '@mui/material/Container';
 
@@ -15,6 +16,7 @@ const App: React.FC = () => (
         <Route path="/" element={<ConnectorListPage />} />
         <Route path="/host" element={<HostPage />} />
         <Route path="/create" element={<CreateWizard />} />
+        <Route path="/create/expert" element={<ExpertCreate />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </Container>

--- a/src/components/CreateWizard.tsx
+++ b/src/components/CreateWizard.tsx
@@ -14,7 +14,7 @@ import {
 import { useForm, FormProvider, Control, Controller } from 'react-hook-form';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation, Link as RouterLink } from 'react-router-dom';
 import { useHost } from '../context/HostContext';
 import AlertSnackbar from './AlertSnackbar';
 import ConfigEditor from './ConfigEditor';
@@ -63,6 +63,8 @@ const CreateWizard: React.FC = () => {
   const [snackbar, setSnackbar] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
+  const showExpert = new URLSearchParams(location.search).get('beta') === 'true';
   const { state } = useHost();
 
   const type = watch('type');
@@ -151,6 +153,11 @@ const CreateWizard: React.FC = () => {
             />
             <Box sx={{ mt: 2 }}>
               <Button onClick={onNext} disabled={!type}>Next</Button>
+              {showExpert && (
+                <Button component={RouterLink} to="/create/expert" sx={{ ml: 2 }}>
+                  Switch to expert mode
+                </Button>
+              )}
             </Box>
           </FormControl>
         )}

--- a/src/components/ExpertCreate.tsx
+++ b/src/components/ExpertCreate.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { Box, Button, TextField, Typography } from '@mui/material';
+import ConfigEditor from './ConfigEditor';
+import AlertSnackbar from './AlertSnackbar';
+import { useHost } from '../context/HostContext';
+import { useNavigate } from 'react-router-dom';
+
+const defaultJson = `{
+  "name": "my-connector",
+  "config": {
+    "connector.class": "",
+    "database.hostname": "",
+    "database.user": "",
+    "database.password": ""
+  }
+}`;
+
+const ExpertCreate: React.FC = () => {
+  const [json, setJson] = useState(defaultJson);
+  const [error, setError] = useState<string | null>(null);
+  const { state } = useHost();
+  const navigate = useNavigate();
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    let payload: any;
+    try {
+      payload = JSON.parse(json);
+    } catch (e: any) {
+      setError('Invalid JSON');
+      return;
+    }
+
+    if (!state.host) {
+      setError('Please set the Debezium Connect host before creating a connector.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch(`${state.host}/connectors`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error('Failed to create connector');
+      navigate('/');
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Typography variant="h6">Expert Connector Configuration</Typography>
+      <TextField
+        multiline
+        minRows={10}
+        value={json}
+        onChange={(e) => setJson(e.target.value)}
+        label="Connector JSON"
+      />
+      <Typography variant="subtitle1">Preview</Typography>
+      <ConfigEditor value={json} readOnly />
+      <Box>
+        <Button variant="contained" onClick={handleSubmit} disabled={submitting}>
+          Submit
+        </Button>
+      </Box>
+      {error && (
+        <AlertSnackbar message={error} onClose={() => setError(null)} />
+      )}
+    </Box>
+  );
+};
+
+export default ExpertCreate;


### PR DESCRIPTION
## Summary
- enable optional expert connector creation screen
- link to expert mode from the wizard when `?beta=true`
- document the expert mode in README

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a4208e2348322814c5a4d927d59a1