### PR TITLE
Add schema-driven connector wizard

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@emotion/styled": "^11.14.0",
     "@hookform/resolvers": "^5.0.1",
     "@mui/icons-material": "^7.1.0",
+    "@rjsf/core": "^5.3.1",
     "@mui/material": "^7.1.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/src/components/CreateWizard.tsx
+++ b/src/components/CreateWizard.tsx
@@ -1,190 +1,158 @@
-// src/components/CreateWizard.tsx
-import React, { useState } from 'react';
+import React, { useState } from "react";
 import {
   Stepper,
   Step,
   StepLabel,
-  Button,
   Box,
-  Typography,
-  TextField,
-  FormControl,
+  Button,
+  CircularProgress,
+  Switch,
+  FormControlLabel,
   MenuItem,
-} from '@mui/material';
-import { useForm, FormProvider, Control, Controller } from 'react-hook-form';
-import * as yup from 'yup';
-import { yupResolver } from '@hookform/resolvers/yup';
-import { useNavigate } from 'react-router-dom';
-import { useHost } from '../context/HostContext';
-import AlertSnackbar from './AlertSnackbar';
-import ConfigEditor from './ConfigEditor';
-import ConnectorFormFields, { ConnectorFieldValues } from './ConnectorFormFields';
-import connectorTemplates from '../templates';
+  InputLabel,
+  FormControl,
+  Select,
+  SelectChangeEvent,
+} from "@mui/material";
+import { JSONSchema7 } from "json-schema";
+import SchemaForm from "./SchemaForm";
+import { useHost } from "../context/HostContext";
+import { createConnector } from "../utils/api";
 
-type ConnectorForm = ConnectorFieldValues & {
-  type: string;
+const STEPS = ["Connector type", "Properties", "Review"];
+
+export default function CreateWizard() {
+  const { state } = useHost();
+  const host = state.host;
+  const [step, setStep] = useState(0);
+  const [connectorType, setConnectorType] = useState<string | null>(null);
+  const [schema, setSchema] = useState<JSONSchema7 | null>(null);
+  const [formData, setFormData] = useState<Record<string, unknown>>({});
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [loadingSchema, setLoadingSchema] = useState(false);
+
+  /** ---- Step 0 --------------------------------------------------------- */
+  const pickType = (t: string) => {
+    setConnectorType(t);
+    setLoadingSchema(true);
+    import(`../templates/${t.toLowerCase()}.schema.json`)
+      .then((mod) => setSchema(mod.default))
+      .catch((e) => console.error("schema load", e))
+      .finally(() => {
+        setLoadingSchema(false);
+        setStep(1);
+      });
+  };
+
+  /** ---- Step 1 --------------------------------------------------------- */
+  const renderPropertiesStep = () => {
+    if (loadingSchema || !schema) return <CircularProgress />;
+    return (
+      <Box>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={showAdvanced}
+              onChange={(e) => setShowAdvanced(e.target.checked)}
+            />
+          }
+          label="Show advanced"
+        />
+        <SchemaForm
+          schema={schema}
+          formData={formData}
+          onChange={setFormData}
+          showAdvanced={showAdvanced}
+        />
+      </Box>
+    );
+  };
+
+  /** ---- Step 2 --------------------------------------------------------- */
+  const renderReview = () => (
+    <pre style={{ maxHeight: 400, overflow: "auto" }}>
+      {JSON.stringify(formData, null, 2)}
+    </pre>
+  );
+
+  const next = () => setStep((s) => s + 1);
+  const back = () => setStep((s) => s - 1);
+
+  const submit = async () => {
+    await createConnector(host, formData as Record<string, unknown>);
+  };
+
+  /** -------------------------------------------------------------------- */
+  return (
+    <Box>
+      <Stepper activeStep={step} sx={{ mb: 4 }}>
+        {STEPS.map((label) => (
+          <Step key={label}>
+            <StepLabel>{label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+
+      {step === 0 && (
+        <ConnectorTypePicker selected={connectorType} onSelect={pickType} />
+      )}
+
+      {step === 1 && renderPropertiesStep()}
+      {step === 2 && renderReview()}
+
+      <Box sx={{ mt: 3 }}>
+        <Button disabled={step === 0} onClick={back}>
+          Back
+        </Button>
+        {step < 2 && (
+          <Button
+            variant="contained"
+            disabled={step === 0 && !connectorType}
+            onClick={next}
+          >
+            Next
+          </Button>
+        )}
+        {step === 2 && (
+          <Button variant="contained" color="success" onClick={submit}>
+            Create connector
+          </Button>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+type PickerProps = {
+  selected: string | null;
+  onSelect: (t: string) => void;
 };
-
-const connectorTypes = [
-  { value: 'mongodb', label: 'MongoDB' },
-  { value: 'mysql', label: 'MySQL' },
-  { value: 'oracle', label: 'Oracle' },
-  { value: 'postgresql', label: 'PostgreSQL' },
-  { value: 'sqlserver', label: 'SQL Server' },
-  { value: 'cassandra', label: 'Cassandra' },
+const CONNECTOR_TYPES = [
+  "MongoDB",
+  "MySQL",
+  "Oracle",
+  "PostgreSQL",
+  "SQLServer",
+  "Cassandra",
 ];
 
-const schema = yup.object({
-  type: yup.string().required('Type is required'),
-  name: yup.string().required('Connector name is required'),
-  host: yup.string().required('Host is required'),
-  port: yup.string().required('Port is required').matches(/^\d+$/, 'Port must be a number'),
-  username: yup.string().required('User is required'),
-  password: yup.string().required('Password is required'),
-  database: yup.string().required('Database name is required'),
-});
-
-const CreateWizard: React.FC = () => {
-  const methods = useForm<ConnectorForm>({
-    defaultValues: {
-      type: '',
-      name: '',
-      host: '',
-      port: '',
-      username: '',
-      password: '',
-      database: ''
-    },
-    resolver: yupResolver(schema),
-    mode: 'onChange'
-  });
-  const { handleSubmit, control, watch, getValues, formState } = methods;
-  const [activeStep, setActiveStep] = useState(0);
-  const [snackbar, setSnackbar] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-  const navigate = useNavigate();
-  const { state } = useHost();
-
-  const type = watch('type');
-  const steps = ['Connector Type', 'Properties', 'Review'];
-
-  const onNext = () => setActiveStep((prev) => prev + 1);
-  const onBack = () => setActiveStep((prev) => prev - 1);
-
-  // Compose config
-  const buildConfig = () => {
-    const data = getValues();
-    const configTemplate = connectorTemplates[data.type] || {};
-    return {
-      ...configTemplate,
-      'database.hostname': data.host,
-      'database.port': Number(data.port),
-      'database.user': data.username,
-      'database.password': data.password,
-      'database.dbname': data.database,
-      // Debezium 2.x uses topic.prefix instead of database.server.name
-      'topic.prefix': data.name,
-      // Provide a sensible default for internal history
-      'schema.history.internal.kafka.bootstrap.servers':
-        configTemplate['schema.history.internal.kafka.bootstrap.servers'] ||
-        'kafka:9092',
-      'schema.history.internal.kafka.topic':
-        `schema-changes.${data.name}`,
-      // (add or override more fields if necessary)
-    };
-  };
-
-  const onSubmit = async () => {
-    const data = getValues();
-    const config = buildConfig();
-
-    // Safety: ensure host is set
-    if (!state.host) {
-      setSnackbar('Please set the Debezium Connect host before creating a connector.');
-      return;
-    }
-
-    setSubmitting(true);
-    try {
-      const res = await fetch(`${state.host}/connectors`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: data.name, config }),
-      });
-      if (!res.ok) {
-        const errorBody = await res.text();
-        throw new Error(errorBody || 'Failed to create connector');
-      }
-      setSnackbar('Connector created successfully');
-      setTimeout(() => navigate('/'), 1000);
-    } catch (err: any) {
-      setSnackbar(`Failed to create connector: ${err.message}`);
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
+function ConnectorTypePicker({ selected, onSelect }: PickerProps) {
+  const handle = (e: SelectChangeEvent<string>) => onSelect(e.target.value);
   return (
-    <FormProvider {...methods}>
-      <Box>
-        <Stepper activeStep={activeStep} sx={{ marginBottom: 3 }}>
-          {steps.map((label) => (
-            <Step key={label}><StepLabel>{label}</StepLabel></Step>
-          ))}
-        </Stepper>
-
-        {/* Step 1: Type Selection */}
-        {activeStep === 0 && (
-          <FormControl fullWidth>
-            <Controller
-              name="type"
-              control={control}
-              render={({ field }) => (
-                <TextField select label="Connector Type" {...field} required>
-                  {connectorTypes.map((opt) => (
-                    <MenuItem key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </MenuItem>
-                  ))}
-                </TextField>
-              )}
-            />
-            <Box sx={{ mt: 2 }}>
-              <Button onClick={onNext} disabled={!type}>Next</Button>
-            </Box>
-          </FormControl>
-        )}
-
-        {/* Step 2: Properties */}
-        {activeStep === 1 && (
-          <Box component="form" noValidate onSubmit={handleSubmit(onNext)} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <ConnectorFormFields control={control as unknown as Control<ConnectorFieldValues>} />
-            <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
-              <Button variant="outlined" onClick={onBack}>Back</Button>
-              <Button type="submit" variant="contained" disabled={!formState.isValid}>Next</Button>
-            </Box>
-          </Box>
-        )}
-
-        {/* Step 3: Review */}
-        {activeStep === 2 && (
-          <Box>
-            <Typography variant="h6">Review Configuration JSON</Typography>
-            <ConfigEditor readOnly value={JSON.stringify({
-              name: getValues('name'),
-              config: buildConfig()
-            }, null, 2)} />
-            <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
-              <Button variant="outlined" onClick={onBack}>Back</Button>
-              <Button variant="contained" onClick={onSubmit} disabled={submitting}>Finish</Button>
-            </Box>
-          </Box>
-        )}
-
-        <AlertSnackbar message={snackbar || ''} onClose={() => setSnackbar(null)} />
-      </Box>
-    </FormProvider>
+    <FormControl fullWidth>
+      <InputLabel id="conn-type-label">Connector type</InputLabel>
+      <Select
+        labelId="conn-type-label"
+        value={selected ?? ""}
+        label="Connector type"
+        onChange={handle}
+      >
+        {CONNECTOR_TYPES.map((t) => (
+          <MenuItem key={t} value={t}>
+            {t}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
   );
-};
-
-export default CreateWizard;
+}

--- a/src/components/SchemaForm.tsx
+++ b/src/components/SchemaForm.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { JSONSchema7 } from "json-schema";
+import { Form as RJSFForm, IChangeEvent } from "@rjsf/core";
+import {
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Typography,
+  Box,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+
+type Props = {
+  schema: JSONSchema7;
+  formData: Record<string, unknown>;
+  onChange: (data: Record<string, unknown>) => void;
+  showAdvanced: boolean;
+};
+
+export default function SchemaForm({
+  schema,
+  formData,
+  onChange,
+  showAdvanced,
+}: Props) {
+  // Break the schema into sections
+  const sections = Object.entries(schema.properties || {});
+
+  const renderSection = (key: string, sectionSchema: JSONSchema7) => {
+    const isBasic = key === "BASIC";
+    if (!isBasic && !showAdvanced) return null;
+
+    return (
+      <Accordion key={key} defaultExpanded={isBasic}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography variant="subtitle1">
+            {sectionSchema.title ?? key.replace(/^ADVANCED__/, "")}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <RJSFForm
+            schema={sectionSchema as JSONSchema7}
+            formData={formData}
+            onChange={(e: IChangeEvent) =>
+              onChange({ ...formData, ...e.formData })
+            }
+            liveValidate
+            noHtml5Validate
+          >
+            <Box />
+          </RJSFForm>
+        </AccordionDetails>
+      </Accordion>
+    );
+  };
+
+  return <>{sections.map(([k, v]) => renderSection(k, v as JSONSchema7))}</>;
+}

--- a/src/templates/cassandra.schema.json
+++ b/src/templates/cassandra.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Debezium – Cassandra connector",
+  "type": "object",
+  "properties": {
+    "BASIC": {
+      "title": "Connection",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Connector Name",
+          "type": "string",
+          "default": "my_cassandra_connector"
+        },
+        "contactPoints": {
+          "title": "Contact Points",
+          "type": "string",
+          "default": "127.0.0.1:9042"
+        },
+        "loadBalancing.localDc": {
+          "title": "Local DC",
+          "type": "string",
+          "default": "datacenter1"
+        },
+        "keyspace": {
+          "title": "Keyspace",
+          "type": "string",
+          "default": "test_keyspace"
+        },
+        "username": {
+          "title": "User",
+          "type": "string",
+          "default": "cassandra"
+        },
+        "password": {
+          "title": "Password",
+          "type": "string",
+          "format": "password"
+        }
+      },
+      "required": ["name", "contactPoints", "username", "password"]
+    }
+  }
+}

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,15 +1,6 @@
-// src/templates/index.ts
-import postgresql from './postgresql.json';
-import mysql from './mysql.json';
-import mongodb from './mongodb.json';
-import oracle from './oracle.json';
-import sqlserver from './sqlserver.json';
-
-const connectorTemplates: Record<string, any> = {
-  postgresql,
-  mysql,
-  mongodb,
-  oracle,
-  sqlserver,
-};
-export default connectorTemplates;
+export { default as mysql } from "./mysql.schema.json";
+export { default as mongodb } from "./mongodb.schema.json";
+export { default as postgresql } from "./postgresql.schema.json";
+export { default as oracle } from "./oracle.schema.json";
+export { default as sqlserver } from "./sqlserver.schema.json";
+export { default as cassandra } from "./cassandra.schema.json";

--- a/src/templates/mongodb.schema.json
+++ b/src/templates/mongodb.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Debezium – MongoDB connector",
+  "type": "object",
+  "properties": {
+    "BASIC": {
+      "title": "Connection",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Connector Name",
+          "type": "string",
+          "default": "my_mongodb_connector"
+        },
+        "mongodb.hosts": {
+          "title": "Hosts",
+          "type": "string",
+          "default": "rs0/localhost:27017"
+        },
+        "mongodb.user": {
+          "title": "User",
+          "type": "string",
+          "default": "dbuser"
+        },
+        "mongodb.password": {
+          "title": "Password",
+          "type": "string",
+          "format": "password"
+        },
+        "database.include.collection.list": {
+          "title": "Collections",
+          "type": "string"
+        }
+      },
+      "required": ["name", "mongodb.hosts", "mongodb.user", "mongodb.password"]
+    }
+  }
+}

--- a/src/templates/mysql.schema.json
+++ b/src/templates/mysql.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Debezium – MySQL connector",
+  "type": "object",
+  "properties": {
+    "BASIC": {
+      "title": "Connection",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Connector Name",
+          "type": "string",
+          "default": "my_mysql_connector",
+          "description": "Unique name inside this Kafka Connect cluster"
+        },
+        "database.hostname": {
+          "title": "Host",
+          "type": "string",
+          "default": "mysql"
+        },
+        "database.port": {
+          "title": "Port",
+          "type": "integer",
+          "default": 3306,
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "database.user": {
+          "title": "User",
+          "type": "string",
+          "default": "debezium"
+        },
+        "database.password": {
+          "title": "Password",
+          "type": "string",
+          "format": "password"
+        },
+        "database.include.list": {
+          "title": "Databases to capture",
+          "type": "string",
+          "default": "inventory",
+          "description": "Comma-separated list or regexp"
+        }
+      },
+      "required": [
+        "name",
+        "database.hostname",
+        "database.user",
+        "database.password"
+      ]
+    },
+    "ADVANCED__Snapshot": {
+      "title": "Snapshot behaviour",
+      "type": "object",
+      "properties": {
+        "snapshot.mode": {
+          "title": "Mode",
+          "type": "string",
+          "enum": [
+            "initial",
+            "initial_only",
+            "when_needed",
+            "schema_only",
+            "no_data",
+            "recovery",
+            "never"
+          ],
+          "default": "initial"
+        },
+        "snapshot.fetch.size": {
+          "title": "Fetch size",
+          "type": "integer",
+          "minimum": 0,
+          "description": "Rows per batch (0 = stream)"
+        }
+      }
+    },
+    "ADVANCED__Performance": {
+      "title": "Performance & buffering",
+      "type": "object",
+      "properties": {
+        "max.batch.size": {
+          "type": "integer",
+          "title": "Max batch size",
+          "default": 2048
+        },
+        "max.queue.size": {
+          "type": "integer",
+          "title": "Max queue size",
+          "default": 8192
+        },
+        "max.queue.size.in.bytes": {
+          "type": "integer",
+          "title": "Max queue bytes",
+          "default": 0
+        }
+      }
+    }
+  }
+}

--- a/src/templates/oracle.schema.json
+++ b/src/templates/oracle.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Debezium – Oracle connector",
+  "type": "object",
+  "properties": {
+    "BASIC": {
+      "title": "Connection",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Connector Name",
+          "type": "string",
+          "default": "my_oracle_connector"
+        },
+        "database.hostname": {
+          "title": "Host",
+          "type": "string",
+          "default": "localhost"
+        },
+        "database.port": {
+          "title": "Port",
+          "type": "integer",
+          "default": 1521
+        },
+        "database.user": {
+          "title": "User",
+          "type": "string",
+          "default": "system"
+        },
+        "database.password": {
+          "title": "Password",
+          "type": "string",
+          "format": "password"
+        },
+        "database.dbname": {
+          "title": "Database Name",
+          "type": "string",
+          "default": "ORCLCDB"
+        }
+      },
+      "required": [
+        "name",
+        "database.hostname",
+        "database.user",
+        "database.password"
+      ]
+    }
+  }
+}

--- a/src/templates/postgresql.schema.json
+++ b/src/templates/postgresql.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Debezium – PostgreSQL connector",
+  "type": "object",
+  "properties": {
+    "BASIC": {
+      "title": "Connection",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Connector Name",
+          "type": "string",
+          "default": "my_postgres_connector"
+        },
+        "database.hostname": {
+          "title": "Host",
+          "type": "string",
+          "default": "localhost"
+        },
+        "database.port": {
+          "title": "Port",
+          "type": "integer",
+          "default": 5432
+        },
+        "database.user": {
+          "title": "User",
+          "type": "string",
+          "default": "myuser"
+        },
+        "database.password": {
+          "title": "Password",
+          "type": "string",
+          "format": "password"
+        },
+        "database.dbname": {
+          "title": "Database Name",
+          "type": "string",
+          "default": "postgres"
+        }
+      },
+      "required": [
+        "name",
+        "database.hostname",
+        "database.user",
+        "database.password"
+      ]
+    }
+  }
+}

--- a/src/templates/sqlserver.schema.json
+++ b/src/templates/sqlserver.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Debezium – SQL Server connector",
+  "type": "object",
+  "properties": {
+    "BASIC": {
+      "title": "Connection",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Connector Name",
+          "type": "string",
+          "default": "my_sqlserver_connector"
+        },
+        "database.hostname": {
+          "title": "Host",
+          "type": "string",
+          "default": "localhost"
+        },
+        "database.port": {
+          "title": "Port",
+          "type": "integer",
+          "default": 1433
+        },
+        "database.user": {
+          "title": "User",
+          "type": "string",
+          "default": "sa"
+        },
+        "database.password": {
+          "title": "Password",
+          "type": "string",
+          "format": "password"
+        },
+        "database.dbname": {
+          "title": "Database Name",
+          "type": "string",
+          "default": "mydb"
+        }
+      },
+      "required": [
+        "name",
+        "database.hostname",
+        "database.user",
+        "database.password"
+      ]
+    }
+  }
+}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -43,3 +43,26 @@ export async function fetchWithTimeout(
     return doFetch();
   }
 }
+
+/**
+ * Create a new Debezium connector
+ */
+export async function createConnector(
+  host: string,
+  config: Record<string, unknown>,
+  timeout = 8000
+): Promise<void> {
+  const res = await fetchWithTimeout(
+    `${host}/connectors`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: String(config.name || ''), config })
+    },
+    timeout
+  );
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || 'Failed to create connector');
+  }
+}


### PR DESCRIPTION
## Summary
- add `@rjsf/core` dependency
- implement `SchemaForm` component for JSON-schema-driven forms
- replace `CreateWizard` with schema-based version and dynamic schema loading
- provide connector schemas for various databases
- update template barrel to export schema files
- fix wizard imports and add `createConnector` API helper
- refine wizard types and code formatting

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npx tsc -noEmit` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_688a4035c2ec8322883166479c02c34d