### PR TITLE
feat: merge base config when creating connectors

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { HostProvider } from './context/HostContext';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders Debezium UI title', () => {
+  render(
+    <HostProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </HostProvider>
+  );
+  const title = screen.getByText(/Debezium UI/i);
+  expect(title).toBeInTheDocument();
 });

--- a/src/pages/ConnectorListPage.tsx
+++ b/src/pages/ConnectorListPage.tsx
@@ -5,11 +5,6 @@ import {
   Card,
   CardContent,
   Typography,
-  Table,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableBody,
   Box,
   Alert,
   Button,
@@ -77,17 +72,16 @@ const ConnectorListPage: React.FC = () => {
 
   return (
     <Box>
-      <Card sx={{ mb: 3 }}>
-        <CardContent>
-          <Typography variant="h5">Connectors Dashboard</Typography>
-          <Typography variant="body2" color="text.secondary">
-            View and manage all Debezium connectors.
-          </Typography>
-        </CardContent>
-      </Card>
+      <Typography variant="h4" gutterBottom>
+        Connectors Dashboard
+      </Typography>
 
       <Box sx={{ mb: 2, display: 'flex', gap: 2 }}>
-        <Button variant="outlined" onClick={loadConnectors} disabled={!isConnected || loading}>
+        <Button
+          variant="outlined"
+          onClick={loadConnectors}
+          disabled={!isConnected || loading}
+        >
           Refresh
         </Button>
         <Button variant="contained" component={RouterLink} to="/create">
@@ -95,18 +89,17 @@ const ConnectorListPage: React.FC = () => {
         </Button>
       </Box>
 
+      {!isConnected && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          Disconnected: Debezium Connect REST server not reachable. No connector data to display.
+        </Alert>
+      )}
+
       <Card>
         <CardContent>
-          <Typography variant="h6" gutterBottom>
-            Active Connectors
-          </Typography>
-          {!isConnected && (
-            <Alert severity="warning" sx={{ mb: 2 }}>
-              Disconnected: Debezium Connect REST server not reachable. No connector data to display.
-            </Alert>
-          )}
-          {loading && <CircularProgress size={24} sx={{ mt: 2 }} />}
-          {isConnected && !loading && (
+          {loading ? (
+            <CircularProgress size={24} sx={{ mt: 2 }} />
+          ) : (
             <ConnectorTable connectors={connectors} onActionComplete={loadConnectors} />
           )}
         </CardContent>


### PR DESCRIPTION
## Summary
- load connector templates and merge with wizard form data
- allow wizard to pass connector type and refresh the dashboard after creation
- simplify dashboard layout and show connectors list with refresh and create actions
- fix unit test by wrapping App with providers

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688d9b5374ec83228ed6d5db45547946